### PR TITLE
Made node extra config also run at stack UPDATES (i.e. scale-out)

### DIFF
--- a/ansible/roles/layer2_rhosp_overcloud/templates/extra-config-post-deployment.yaml.j2
+++ b/ansible/roles/layer2_rhosp_overcloud/templates/extra-config-post-deployment.yaml.j2
@@ -26,4 +26,4 @@ resources:
       name: ExtraDeployments
       servers:  {get_param: servers}
       config: {get_resource: ExtraConfig}
-      actions: ['CREATE'] # Only do this on CREATE
+      actions: ['CREATE', 'UPDATE'] 


### PR DESCRIPTION
This prevents novnc base_url from being overwritten at scale-out