### PR TITLE
Revert "- Replace service module to use systemd. Make masquing more simple."

### DIFF
--- a/ansible/roles/layer1/tasks/prepare_host.yml
+++ b/ansible/roles/layer1/tasks/prepare_host.yml
@@ -19,26 +19,30 @@
 
 - name: system-upgrade
   yum: name=* state=latest
-
 - name: ensure prerequisite packages are present
   yum: name=libvirt,libvirt-client,qemu-kvm,qemu-img,libvirt-python,virt-install,nfs-utils,iptables-services state=latest
   #reboot machine if necessary https://bugzilla.redhat.com/show_bug.cgi?id=950436
   register: prereqs
 
 - name: disable & stop NetworkManager
-  systemd: name=NetworkManager state=stopped enabled=no masked=yes
+  service: name=NetworkManager state=stopped enabled=no
+- name: mask NetworkManager
+  shell: systemctl status NetworkManager | grep masked || systemctl mask NetworkManager
+  register: mask_nm
+  changed_when: "'Created symlink' in mask_nm.stdout"
 
 - name: disable & stop firewalld
-  systemd: name=firewalld state=stopped enabled=no masked=yes
-  ignore_errors: yes
-# ignore_errors is here, just in case firewalld is not installed.
-
+  service: name=firewalld state=stopped enabled=no
+- name: mask firewalld
+  shell: systemctl status firewalld | grep masked || systemctl mask firewalld
+  register: mask_firewalld
+  changed_when: "'Created symlink' in mask_firewalld.stdout"
 - name: enable & start iptables service
-  systemd: name=iptables state=started enabled=yes
+  service: name=iptables state=started enabled=yes
 # - name: enable & start iptables6 service
 #   service: name=iptables6 state=started enables=yes
 - name: enable and start libvirtd
-  systemd: name=libvirtd enabled=yes state=started
+  service: name=libvirtd enabled=yes state=started
 
 # https://support.ansible.com/hc/en-us/articles/201958037-Reboot-a-server-and-wait-for-it-to-come-back
 - name: restart machine


### PR DESCRIPTION
Reverts wrichter/hailstorm#65

Seems this is only present in newer ansible distributions?

ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/Users/wolfram/git/hailstorm/ansible/roles/layer1/tasks/prepare_host.yml': line 28, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: disable & stop NetworkManager
  ^ here


The error appears to have been in '/Users/wolfram/git/hailstorm/ansible/roles/layer1/tasks/prepare_host.yml': line 28, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: disable & stop NetworkManager
  ^ here